### PR TITLE
Limit QC reports to flagged issues only

### DIFF
--- a/gpi_qc_tool.py
+++ b/gpi_qc_tool.py
@@ -253,7 +253,12 @@ def qc_pipeline(csv_path: Path, features_path: Path, output_dir: Path,
     for idx, raw in df["Attribute"].fillna("").astype(str).items():
         s = raw.strip()
         if s and s.count("|") % 2 == 1:
-            attr_issues.append({"RowIndex": idx, "Attribute": raw, "Issue": "Odd number of '|' separators"})
+            attr_issues.append({
+                "RowIndex": idx,
+                "Point ID": df.at[idx, "Point ID"],
+                "Attribute": raw,
+                "Issue": "Odd number of '|' separators"
+            })
     attr_issues_df = pd.DataFrame(attr_issues) if attr_issues else pd.DataFrame({"Info": ["No issues found"]})
 
     # Geometry warnings
@@ -326,8 +331,40 @@ def qc_pipeline(csv_path: Path, features_path: Path, output_dir: Path,
             )
         )
         linework_df = agg.reset_index()
+        if not linework_df.empty:
+            issue_mask = linework_df["Issue"] != "OK"
+            linework_df = linework_df.loc[issue_mask].copy()
+            if not linework_df.empty and not events_df.empty and {"Base", "LineID", "Point ID"}.issubset(events_df.columns):
+                def _format_ids(series: pd.Series) -> str:
+                    ids = {str(x).strip() for x in series if pd.notna(x) and str(x).strip()}
+                    return ", ".join(sorted(ids))
+
+                pid_map = (
+                    events_df.groupby(["Base", "LineID"])["Point ID"].apply(_format_ids).reset_index()
+                )
+                linework_df = linework_df.merge(pid_map, on=["Base", "LineID"], how="left")
+        if linework_df.empty:
+            linework_df = pd.DataFrame({"Info": ["All lines have matching start/end/close (as detected)"]})
+            events_df = pd.DataFrame({"Info": ["No line events associated with flagged issues"]})
+        else:
+            if not events_df.empty and {"Base", "LineID"}.issubset(events_df.columns):
+                keys = set(
+                    zip(
+                        linework_df["Base"].fillna(""),
+                        linework_df["LineID"].fillna("")
+                    )
+                )
+                events_df = events_df[
+                    events_df.apply(
+                        lambda r: (str(r.get("Base", "") or ""), str(r.get("LineID", "") or "")) in keys,
+                        axis=1
+                    )
+                ]
+                if events_df.empty:
+                    events_df = pd.DataFrame({"Info": ["No line events associated with flagged issues"]})
     else:
         linework_df = pd.DataFrame({"Info": ["All lines have matching start/end/close (as detected)"]})
+        events_df = pd.DataFrame({"Info": ["No line events associated with flagged issues"]})
 
     # Elevation outliers (terrain-eligible only)
     terrain_df = df[df["BaseCode"].isin(eligible_bases)].reset_index(drop=True)
@@ -336,52 +373,15 @@ def qc_pipeline(csv_path: Path, features_path: Path, output_dir: Path,
         max_k=max_k, iqr_mult=iqr_mult, mad_mult=mad_mult
     )
 
-    # Points that are not associated with any detected issue
-    issue_indices = set()
-    issue_point_ids = set()
-
-    def collect_issue_entries(frame: pd.DataFrame, include_index: bool = True):
-        if isinstance(frame, pd.DataFrame) and not frame.empty and "Info" not in frame.columns:
-            if include_index:
-                issue_indices.update(frame.index.tolist())
-            if "Point ID" in frame.columns:
-                ids = frame["Point ID"].dropna().astype(str).str.strip()
-                issue_point_ids.update(ids[ids != ""])  # ignore blanks
-
-    collect_issue_entries(non_numeric_df)
-    collect_issue_entries(missing_df)
-    collect_issue_entries(dups)
-    collect_issue_entries(geom_df)
-    collect_issue_entries(unknown_codes)
-    collect_issue_entries(local_outliers, include_index=False)
-
-    if isinstance(attr_issues_df, pd.DataFrame) and not attr_issues_df.empty and "Info" not in attr_issues_df.columns:
-        attr_idx = attr_issues_df["RowIndex"].dropna().astype(int)
-        issue_indices.update(attr_idx.tolist())
-        mapped_ids = df.loc[attr_idx, "Point ID"].dropna().astype(str).str.strip()
-        issue_point_ids.update(mapped_ids[mapped_ids != ""])
-
-    pid_series = df["Point ID"].fillna("").astype(str).str.strip()
-    issue_mask = df.index.isin(issue_indices)
-    if issue_point_ids:
-        issue_mask |= pid_series.isin(issue_point_ids)
-
-    ok_points_df = df.loc[~issue_mask, [
-        "Point ID", "Northing", "Easting", "Elevation", "Feature Code", "Attribute"
-    ]].copy()
-
     # Build Summary counts
     def count_or_zero(d: pd.DataFrame) -> int:
         return 0 if "Info" in d.columns else len(d)
-
-    ok_count = len(ok_points_df)
 
     summary = pd.DataFrame({
         "Category": [
             "Unknown Feature Codes", "Linework Issues", "Linework Events",
             "Non-numeric", "Missing Required", "Duplicate Point IDs",
-            "Geometry Warnings", "Attribute Format Issues", "Local Elevation Outliers",
-            "Points Without Issues"
+            "Geometry Warnings", "Attribute Format Issues", "Local Elevation Outliers"
         ],
         "Count": [
             count_or_zero(unknown_codes),
@@ -392,8 +392,7 @@ def qc_pipeline(csv_path: Path, features_path: Path, output_dir: Path,
             0 if "Info" in dups.columns else len(dups),
             count_or_zero(geom_df),
             count_or_zero(attr_issues_df),
-            count_or_zero(local_outliers),
-            ok_count
+            count_or_zero(local_outliers)
         ]
     })
 
@@ -408,8 +407,7 @@ def qc_pipeline(csv_path: Path, features_path: Path, output_dir: Path,
         "duplicates": dups,
         "geometry": geom_df,
         "attr_issues": attr_issues_df,
-        "elev_outliers": local_outliers,
-        "ok_points": ok_points_df
+        "elev_outliers": local_outliers
     }
 
 # ============ Reporting (Excel or HTML) ============
@@ -433,7 +431,6 @@ def write_excel_report(dfs: dict, output_path: Path):
         write_tab("Geometry Warnings", "geometry")
         write_tab("Attribute Format Issues", "attr_issues")
         write_tab("Local Elevation Outliers", "elev_outliers")
-        write_tab("Points Without Issues", "ok_points")
 
     # Optional header styling
     if load_workbook and PatternFill and Font:
@@ -518,7 +515,6 @@ def write_html_report(dfs: dict, output_path: Path, title="GPI Survey QC Report"
         ("Geometry Warnings","geometry"),
         ("Attribute Format Issues","attr_issues"),
         ("Local Elevation Outliers","elev_outliers"),
-        ("Points Without Issues","ok_points"),
     ]
     link_items = []
     for label, key in sections:
@@ -561,7 +557,7 @@ def write_html_report(dfs: dict, output_path: Path, title="GPI Survey QC Report"
     {section_block("Linework Issues", "linework_issues",
       "Flags: 'Ended/closed with no prior start' or 'Started but never ended/closed'.")}
     {section_block("Linework Events", "linework_events",
-      "All parsed START/END/CLOSE events with base + line ID.")}
+      "START/END/CLOSE events tied to the flagged linework above.")}
     {section_block("Non-numeric", "non_numeric")}
     {section_block("Missing Required", "missing")}
     {section_block("Duplicate Point IDs", "duplicates")}
@@ -570,8 +566,6 @@ def write_html_report(dfs: dict, output_path: Path, title="GPI Survey QC Report"
       "Checks for odd number of '|' separators in Attribute column.")}
     {section_block("Local Elevation Outliers", "elev_outliers",
       "Terrain-eligible codes only (Attribute Type != 'Do Not Include').")}
-    {section_block("Points Without Issues", "ok_points",
-      "Subset of survey points without any detected QC findings above.")}
   </main>
 </div>
 </body>


### PR DESCRIPTION
## Summary
- include the triggering point IDs in attribute format issues and restrict linework issues/events to flagged items only
- remove the "Points Without Issues" outputs so the Excel and HTML reports focus solely on errors
- refresh report summaries and messaging to reflect the tighter scope of the data shown

## Testing
- python -m compileall gpi_qc_tool.py

------
https://chatgpt.com/codex/tasks/task_b_68dc4f2528d8832fa02d8197b759d3de